### PR TITLE
Enable Adoption Insights plugin

### DIFF
--- a/documentation/modules/ROOT/examples/challenge-03/rbac-policies.csv
+++ b/documentation/modules/ROOT/examples/challenge-03/rbac-policies.csv
@@ -33,6 +33,8 @@
 # Bulk import
 #p, role:default/administrators, bulk-import, use, allow
 #p, role:default/administrators, bulk.import, use, allow
+# Adoption Insights permissions
+#p, role:default/admins, adoption-insights.events.read, read, allow
 
 # My Own Admin User
 #g, user:default/root, role:default/administrators
@@ -56,6 +58,8 @@ p, role:default/team-a, scaffolder.action.execute, use, allow
 p, role:default/team-a, scaffolder.task.read, read, allow
 p, role:default/team-a, scaffolder.task.create, create, allow
 p, role:default/team-a, scaffolder.task.cancel, use, allow
+# Adoption Insights permissions
+p, role:default/team-a, adoption-insights.events.read, read, allow
 
 # Team-B Role
 # Catalog permissions

--- a/documentation/modules/ROOT/examples/challenge-07/rhdh-app-config-cm-github.yaml
+++ b/documentation/modules/ROOT/examples/challenge-07/rhdh-app-config-cm-github.yaml
@@ -1,0 +1,118 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: rhdh-app-config
+data:
+  rhdh-app-config.yaml: |
+    backend:
+      baseUrl: https://$rhdhname.$basedomain
+      cors:
+        origin: https://$rhdhname.$basedomain
+    organization:
+      name: "My Organization"
+    app:
+      baseUrl: https://$rhdhname.$basedomain
+      title: "My Adventure with Red Hat Developer Hub"
+      branding:
+        theme:
+          light:
+            primaryColor: '#38be8b'
+            headerColor1: 'hsl(204 100% 71%)'
+            headerColor2: 'color(a98-rgb 1 0 0)'
+            navigationIndicatorColor: '#be0000'
+          dark:
+            primaryColor: '#ab75cf'
+            headerColor1: '#0000d0'
+            headerColor2: 'rgb(255 246 140)'
+            navigationIndicatorColor: '#f4eea9'
+      # Enabling Analytics
+      analytics:
+        adoptionInsights:
+          maxBufferSize: 25
+          flushInterval: 6000
+          debug: false
+          licensedUsers: 1000
+
+    # Authorization GitHub
+    signInPage: github
+    dangerouslyAllowSignInWithoutUserInCatalog: false
+    auth:
+      environment: production
+      providers:
+        github:
+          production:
+            clientId: ${AUTH_GITHUB_CLIENT_ID}
+            clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
+
+    # Integrations
+    integrations:
+      github:
+        - host: github.com
+          #token: ${AUTH_GITHUB_TOKEN}
+          apps:
+            - appId: ${AUTH_GITHUB_APP_ID}
+              clientId: ${AUTH_GITHUB_CLIENT_ID}
+              clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
+              webhookUrl: ${AUTH_GITHUB_WEBHOOK_URL}
+              webhookSecret: ${AUTH_GITHUB_WEBHOOK_SECRET}
+              privateKey: |
+                ${AUTH_GITHUB_PRIVATE_KEY_FILE}
+
+    # Catalog
+    catalog:
+      providers:
+        github:
+          providerId:
+            organization: ${GITHUB_ORGANIZATION}
+            schedule:
+              frequency:
+                minutes: 30
+              initialDelay:
+                seconds: 15
+              timeout:
+                minutes: 15
+        githubOrg:
+          githubUrl: "https://github.com"
+          orgs: [ "${GITHUB_ORGANIZATION}" ]
+          schedule:
+            frequency:
+              minutes: 30
+            initialDelay:
+              seconds: 15
+            timeout:
+              minutes: 15
+
+      # Locations
+      locations:
+        - type: url
+          target: https://github.com/rhdh-adventure-organization/sample-template/blob/main/template.yaml
+          rules:
+            - allow: [Template]
+        - type: url
+          target: https://github.com/rhdh-adventure-organization/angular-template-gh/blob/main/template.yaml
+          rules:
+            - allow: [Template]
+        - type: url
+          target: https://github.com/rhdh-adventure-organization/angular-template-gl/blob/main/template.yaml
+          rules:
+            - allow: [Template]
+        - type: url
+          target: https://github.com/redhat-developer/red-hat-developer-hub-software-templates/blob/main/templates.yaml
+          rules:
+            - allow: [Template]
+
+    # RBAC
+    permission:
+      enabled: true
+      rbac:
+        admin:
+          users:
+            - name: user:default/root
+        policies-csv-file: /opt/app-root/src/rbac/rbac-policies.csv
+        conditionalPoliciesFile: /opt/app-root/src/rbac/rbac-conditional-policies.yaml
+        policyFileReload: true
+        pluginsWithPermission:
+          - catalog
+          - scaffolder
+          - permission

--- a/documentation/modules/ROOT/examples/challenge-07/rhdh-app-config-cm-gitlab.yaml
+++ b/documentation/modules/ROOT/examples/challenge-07/rhdh-app-config-cm-gitlab.yaml
@@ -1,0 +1,112 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: rhdh-app-config
+data:
+  rhdh-app-config.yaml: |
+    backend:
+      baseUrl: https://$rhdhname.$basedomain
+      cors:
+        origin: https://$rhdhname.$basedomain
+    organization:
+      name: "My Organization"
+    app:
+      baseUrl: https://$rhdhname.$basedomain
+      title: "My Adventure with Red Hat Developer Hub"
+      branding:
+        theme:
+          light:
+            primaryColor: '#38be8b'
+            headerColor1: 'hsl(204 100% 71%)'
+            headerColor2: 'color(a98-rgb 1 0 0)'
+            navigationIndicatorColor: '#be0000'
+          dark:
+            primaryColor: '#ab75cf'
+            headerColor1: '#0000d0'
+            headerColor2: 'rgb(255 246 140)'
+            navigationIndicatorColor: '#f4eea9'
+      # Enabling Analytics
+      analytics:
+        adoptionInsights:
+          maxBufferSize: 25
+          flushInterval: 6000
+          debug: false
+          licensedUsers: 1000
+
+    # Authorization GitLab
+    signInPage: gitlab
+    dangerouslyAllowSignInWithoutUserInCatalog: false
+    auth:
+      environment: production
+      providers:
+        gitlab:
+          production:
+            clientId: ${AUTH_GITLAB_CLIENT_ID}
+            clientSecret: ${AUTH_GITLAB_CLIENT_SECRET}
+            audience: https://gitlab.${basedomain}
+
+    # Integrations
+    integrations:
+      gitlab:
+        - host: gitlab.${basedomain}
+          token: ${AUTH_GITLAB_TOKEN}
+          apiBaseUrl: https://gitlab.${basedomain}/api/v4
+          baseUrl: https://gitlab.${basedomain}
+
+    # Catalog
+    catalog:
+      providers:
+        gitlab:
+          myGitLab:
+            host: gitlab.${basedomain} # Identifies one of the hosts set up in the integrations
+            apiBaseUrl: https://gitlab.${basedomain}/api/v4
+            branch: main # Optional. Used to discover on a specific branch
+            fallbackBranch: master # Optional. Fallback to be used if there is no default branch configured at the Gitlab repository. It is only used, if `branch` is undefined. Uses `master` as default
+            skipForkedRepos: false # Optional. If the project is a fork, skip repository
+            entityFilename: catalog-info.yaml # Optional. Defaults to `catalog-info.yaml`
+            projectPattern: '[\s\S]*' # Optional. Filters found projects based on provided patter. Defaults to `[\s\S]*`, which means to not filter anything
+            schedule: # optional; same options as in TaskScheduleDefinition
+              # supports cron, ISO duration, "human duration" as used in code
+              frequency: { minutes: 30 }
+              # supports ISO duration, "human duration" as used in code
+              timeout: { minutes: 15 }
+            orgEnabled: true
+            #group: org/teams # Required for gitlab.com when `orgEnabled: true`. Optional for self managed. Must not end with slash. Accepts only groups under the provided path (which will be stripped)
+            allowInherited: true # Allow groups to be ingested even if there are no direct members.
+            groupPattern: '[\s\S]*'
+            restrictUsersToGroup: false
+
+      # Locations
+      locations:
+        - type: url
+          target: https://github.com/rhdh-adventure-organization/sample-template/blob/main/template.yaml
+          rules:
+            - allow: [Template]
+        - type: url
+          target: https://github.com/rhdh-adventure-organization/angular-template-gh/blob/main/template.yaml
+          rules:
+            - allow: [Template]
+        - type: url
+          target: https://github.com/rhdh-adventure-organization/angular-template-gl/blob/main/template.yaml
+          rules:
+            - allow: [Template]
+        - type: url
+          target: https://github.com/redhat-developer/red-hat-developer-hub-software-templates/blob/main/templates.yaml
+          rules:
+            - allow: [Template]
+
+    # RBAC
+    permission:
+      enabled: true
+      rbac:
+        admin:
+          users:
+            - name: user:default/root
+        policies-csv-file: /opt/app-root/src/rbac/rbac-policies.csv
+        conditionalPoliciesFile: /opt/app-root/src/rbac/rbac-conditional-policies.yaml
+        policyFileReload: true
+        pluginsWithPermission:
+          - catalog
+          - scaffolder
+          - permission

--- a/documentation/modules/ROOT/examples/challenge-07/rhdh-dynamic-plugins-cm-github-01.yaml
+++ b/documentation/modules/ROOT/examples/challenge-07/rhdh-dynamic-plugins-cm-github-01.yaml
@@ -16,9 +16,6 @@ data:
         disabled: false
       - package: ./dynamic-plugins/dist/backstage-community-plugin-rbac
         disabled: false
-      # Analytics
-      - package: './dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment'
-        disabled: false
       # DevQuotes
       - package: oci://quay.io/rhdh-adventure-organization/backstage-dev-quotes-dynamic-plugin:v0.0.1!parsifal-m-plugin-dev-quotes-homepage
         disabled: false
@@ -55,3 +52,35 @@ data:
                     mountPoint: entity.page.todo
       - package: oci://quay.io/rhdh-adventure-organization/backstage-community-plugin-todo:v0.1.2!backstage-community-plugin-todo-backend-dynamic
         disabled: false
+      # Adoption Analytics
+      - package: './dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment'
+        disabled: true
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-adoption-insights:bs_1.35.1__0.0.2!red-hat-developer-hub-backstage-plugin-adoption-insights
+        disabled: false
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              red-hat-developer-hub.backstage-plugin-adoption-insights:
+                appIcons:
+                  - name: adoptionInsightsIcon
+                    importName: AdoptionInsightsIcon
+                dynamicRoutes:
+                  - path: /adoption-insights
+                    importName: AdoptionInsightsPage
+                    menuItem:
+                      icon: adoptionInsightsIcon
+                      text: Adoption Insights
+                menuItems:
+                  adoption-insights:
+                    parent: admin
+                    icon: adoptionInsightsIcon
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-adoption-insights-backend:bs_1.35.1__0.0.2!red-hat-developer-hub-backstage-plugin-adoption-insights-backend-dynamic
+        disabled: false
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights:bs_1.35.1__0.0.2!red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights
+        disabled: false
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              red-hat-developer-hub.backstage-plugin-analytics-module-adoption-insights:
+                apiFactories:
+                  - importName: AdoptionInsightsAnalyticsApiFactory

--- a/documentation/modules/ROOT/examples/challenge-07/rhdh-dynamic-plugins-cm-gitlab-01.yaml
+++ b/documentation/modules/ROOT/examples/challenge-07/rhdh-dynamic-plugins-cm-gitlab-01.yaml
@@ -22,9 +22,6 @@ data:
       # RBAC Plugins
       - package: ./dynamic-plugins/dist/backstage-community-plugin-rbac
         disabled: false
-      # Analytics
-      - package: './dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment'
-        disabled: false
       # DevQuotes
       - package: oci://quay.io/rhdh-adventure-organization/backstage-dev-quotes-dynamic-plugin:v0.0.1!parsifal-m-plugin-dev-quotes-homepage
         disabled: false
@@ -61,3 +58,35 @@ data:
                     mountPoint: entity.page.todo
       - package: oci://quay.io/rhdh-adventure-organization/backstage-community-plugin-todo:v0.1.2!backstage-community-plugin-todo-backend-dynamic
         disabled: false
+      # Adoption Analytics
+      - package: './dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment'
+        disabled: true
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-adoption-insights:bs_1.35.1__0.0.2!red-hat-developer-hub-backstage-plugin-adoption-insights
+        disabled: false
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              red-hat-developer-hub.backstage-plugin-adoption-insights:
+                appIcons:
+                  - name: adoptionInsightsIcon
+                    importName: AdoptionInsightsIcon
+                dynamicRoutes:
+                  - path: /adoption-insights
+                    importName: AdoptionInsightsPage
+                    menuItem:
+                      icon: adoptionInsightsIcon
+                      text: Adoption Insights
+                menuItems:
+                  adoption-insights:
+                    parent: admin
+                    icon: adoptionInsightsIcon
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-adoption-insights-backend:bs_1.35.1__0.0.2!red-hat-developer-hub-backstage-plugin-adoption-insights-backend-dynamic
+        disabled: false
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights:bs_1.35.1__0.0.2!red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights
+        disabled: false
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              red-hat-developer-hub.backstage-plugin-analytics-module-adoption-insights:
+                apiFactories:
+                  - importName: AdoptionInsightsAnalyticsApiFactory

--- a/documentation/modules/ROOT/examples/challenge-07/values-01-github.yaml
+++ b/documentation/modules/ROOT/examples/challenge-07/values-01-github.yaml
@@ -14,9 +14,6 @@ global:
       # RBAC Plugins
       - package: ./dynamic-plugins/dist/backstage-community-plugin-rbac
         disabled: false
-      # Analytics
-      - package: './dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment'
-        disabled: false
       # DevQuotes
       - package: oci://quay.io/rhdh-adventure-organization/backstage-dev-quotes-dynamic-plugin:v0.0.1!parsifal-m-plugin-dev-quotes-homepage
         disabled: false
@@ -53,6 +50,38 @@ global:
                     mountPoint: entity.page.todo
       - package: oci://quay.io/rhdh-adventure-organization/backstage-community-plugin-todo:v0.1.2!backstage-community-plugin-todo-backend-dynamic
         disabled: false
+      # Adoption Analytics
+      - package: './dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment'
+        disabled: true
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-adoption-insights:bs_1.35.1__0.0.2!red-hat-developer-hub-backstage-plugin-adoption-insights
+        disabled: false
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              red-hat-developer-hub.backstage-plugin-adoption-insights:
+                appIcons:
+                  - name: adoptionInsightsIcon
+                    importName: AdoptionInsightsIcon
+                dynamicRoutes:
+                  - path: /adoption-insights
+                    importName: AdoptionInsightsPage
+                    menuItem:
+                      icon: adoptionInsightsIcon
+                      text: Adoption Insights
+                menuItems:
+                  adoption-insights:
+                    parent: admin
+                    icon: adoptionInsightsIcon
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-adoption-insights-backend:bs_1.35.1__0.0.2!red-hat-developer-hub-backstage-plugin-adoption-insights-backend-dynamic
+        disabled: false
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights:bs_1.35.1__0.0.2!red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights
+        disabled: false
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              red-hat-developer-hub.backstage-plugin-analytics-module-adoption-insights:
+                apiFactories:
+                  - importName: AdoptionInsightsAnalyticsApiFactory
 upstream:
   backstage:
     extraAppConfig:

--- a/documentation/modules/ROOT/examples/challenge-07/values-01-gitlab.yaml
+++ b/documentation/modules/ROOT/examples/challenge-07/values-01-gitlab.yaml
@@ -19,9 +19,6 @@ global:
       # RBAC Plugins
       - package: ./dynamic-plugins/dist/backstage-community-plugin-rbac
         disabled: false
-      # Analytics
-      - package: './dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment'
-        disabled: false
       # DevQuotes
       - package: oci://quay.io/rhdh-adventure-organization/backstage-dev-quotes-dynamic-plugin:v0.0.1!parsifal-m-plugin-dev-quotes-homepage
         disabled: false
@@ -58,6 +55,38 @@ global:
                     mountPoint: entity.page.todo
       - package: oci://quay.io/rhdh-adventure-organization/backstage-community-plugin-todo:v0.1.2!backstage-community-plugin-todo-backend-dynamic
         disabled: false
+      # Adoption Analytics
+      - package: './dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment'
+        disabled: true
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-adoption-insights:bs_1.35.1__0.0.2!red-hat-developer-hub-backstage-plugin-adoption-insights
+        disabled: false
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              red-hat-developer-hub.backstage-plugin-adoption-insights:
+                appIcons:
+                  - name: adoptionInsightsIcon
+                    importName: AdoptionInsightsIcon
+                dynamicRoutes:
+                  - path: /adoption-insights
+                    importName: AdoptionInsightsPage
+                    menuItem:
+                      icon: adoptionInsightsIcon
+                      text: Adoption Insights
+                menuItems:
+                  adoption-insights:
+                    parent: admin
+                    icon: adoptionInsightsIcon
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-adoption-insights-backend:bs_1.35.1__0.0.2!red-hat-developer-hub-backstage-plugin-adoption-insights-backend-dynamic
+        disabled: false
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights:bs_1.35.1__0.0.2!red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights
+        disabled: false
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              red-hat-developer-hub.backstage-plugin-analytics-module-adoption-insights:
+                apiFactories:
+                  - importName: AdoptionInsightsAnalyticsApiFactory
 upstream:
   backstage:
     extraAppConfig:

--- a/documentation/modules/ROOT/pages/challenge-07-solution.adoc
+++ b/documentation/modules/ROOT/pages/challenge-07-solution.adoc
@@ -30,17 +30,136 @@ this xref:01-setup.adoc#ocpsetup-monitoring[step] of the setup.
 Additionally Red Hat Developer Hub provides and integrates some functionalities to monitor the status of the application.
 These capabilities are:
 
-* Metrics for gather insights and monitor performance of the instance. Information link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html-single/monitoring_and_logging/index[here]
-* Audit logs to register user activities, system events, and data changes. Information link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/audit_log/assembly-audit-log[here].
-* Telemetry data for collecting and analyzing to improve the experience. Information link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html-single/telemetry_data_collection/index[here].
+* Metrics for gather insights and monitor performance of the instance. Information link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/monitoring_and_logging/index[here]
+* Audit logs to register user activities, system events, and data changes. Information link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/audit_logs_in_red_hat_developer_hub/index[here].
+* Telemetry data for collecting and analyzing to improve the experience. Information link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/telemetry_data_collection/index[here].
 
-Additionally, Red Hat Developer Hub can be extended to integrate some plugins of the community to gather more information
-and insights. Some of those plugins are:
+Additionally, Red Hat Developer Hub provides a plugin to deliver detailed analytics and insights on adoption
+and engagement of the platform. This plugin is called Adoption Insights. To enable it, you need to install
+the plugin and configure it with the correct parameters. This configuration must be added into the `a`
 
-* link:https://github.com/backstage/community-plugins/blob/main/workspaces/analytics/plugins/analytics-module-matomo/README.md[Analytics Module: Matomo Analytics]
-* link:https://backstage.io/docs/plugins/analytics/[Plugin Analytics]
+Modify `rhdh-app-config` ConfigMap to add this configuration (as part of the `app` block) as:
 
-TIP: Those plugins could be installed using the dynamic plugin framework.
+[.console-input]
+[source, yaml, subs="+macros,+attributes"]
+----
+  rhdh-app-config.yaml: |
+    # ...Other configurations...
+    app:
+      # ...Other configurations...
+      # Enabling Analytics
+      analytics:
+        adoptionInsights:
+          maxBufferSize: 25
+          flushInterval: 6000
+          debug: false
+          licensedUsers: 1000
+----
+
+Apply the configuration for your Git provider:
+
+[tabs]
+====
+GitHub::
++
+--
+[.console-input]
+[source, bash, subs="+macros,+attributes"]
+----
+sed -e "s|\$rhdhname|$rhdhname|g" \
+    -e "s|\$basedomain|$basedomain|g" \
+    ./documentation/modules/ROOT/examples/challenge-07/rhdh-app-config-cm-github.yaml | oc apply -f -
+----
+
+The operator will redeploy the instance to apply the new changes. For a Helm release, we need
+to rollout the deployment.
+
+[.console-input]
+[source, bash, subs="+macros,+attributes"]
+----
+oc rollout restart deployment/rhdh-developer-hub
+----
+--
+GitLab::
++
+--
+[.console-input]
+[source, bash, subs="+macros,+attributes"]
+----
+sed -e "s|\$rhdhname|$rhdhname|g" \
+    -e "s|\$basedomain|$basedomain|g" \
+    ./documentation/modules/ROOT/examples/challenge-07/rhdh-app-config-cm-gitlab.yaml | oc apply -f -
+----
+
+The operator will redeploy the instance to apply the new changes. For a Helm release, we need
+to rollout the deployment.
+
+[.console-input]
+[source, bash, subs="+macros,+attributes"]
+----
+oc rollout restart deployment/rhdh-developer-hub
+----
+====
+
+Once we have the configuration for the Adoption Insights plugin, we can continue as:
+
+[tabs]
+====
+By Helm Chart::
++
+--
+Extend the `values.yaml` file to add the list of plugins to use and upgrade the Helm release:
+
+For GitHub:
+
+[.console-input]
+[source, bash, subs="+macros,+attributes"]
+----
+helm upgrade --install rhdh \
+    openshift-helm-charts/redhat-developer-hub \
+    -f ./documentation/modules/ROOT/examples/challenge-07/values-01-github.yaml \
+    --set global.clusterRouterBase=$basedomain
+----
+
+For GitLab:
+
+[.console-input]
+[source, bash, subs="+macros,+attributes"]
+----
+helm upgrade --install rhdh \
+    openshift-helm-charts/redhat-developer-hub \
+    -f ./documentation/modules/ROOT/examples/challenge-07/values-01-gitlab.yaml \
+    --set global.clusterRouterBase=$basedomain
+----
+
+WARNING: The name used for the Red Hat Developer Hub instance is `rhdh`. If you choose a different name, please replace that pattern in the command with the name of your instance.
+--
+By Operator::
++
+--
+For GitHub:
+
+[.console-input]
+[source, bash, subs="+macros,+attributes"]
+----
+oc apply -f ./documentation/modules/ROOT/examples/challenge-07/rhdh-dynamic-plugins-cm-github-01.yaml
+----
+
+For GitLab:
+
+[.console-input]
+[source, bash, subs="+macros,+attributes"]
+----
+oc apply -f ./documentation/modules/ROOT/examples/challenge-07/rhdh-dynamic-plugins-cm-gitlab-01.yaml
+----
+--
+====
+
+Once the Red Hat Developer Hub is redeployed is created, the user can visualize the insights
+from the **Adoption Insights** menu under the **Administration** block. A similar dashboard
+is available:
+
+image::challenge-07/rhdh-adoption-insights-dashboard.png[]
 
 [#metrics-solution]
 == 🧞👨‍🔬 Metrics

--- a/documentation/modules/ROOT/pages/challenge-07.adoc
+++ b/documentation/modules/ROOT/pages/challenge-07.adoc
@@ -29,8 +29,8 @@ Which tools can be used? What is provided by Red Hat Developer Hub or Red Hat Op
 To resolve this challenge you can start checking the following references:
 
 * link:https://docs.openshift.com/container-platform/4.16/observability/monitoring/monitoring-overview.html[OpenShift Monitoring overview]
-* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html-single/monitoring_and_logging/index[Monitoring and Logging]
-* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/audit_log/index[Audit Log]
+* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/monitoring_and_logging/index[Monitoring and Logging]
+* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/audit_logs_in_red_hat_developer_hub/index[Audit Log]
 
 [#tools-solution]
 === 🧞🧰 Tools Solution
@@ -44,8 +44,9 @@ Which metrics are exposed? How are they integrated in OpenShift? How could I get
 
 To resolve this challenge you can start checking the following references:
 
-* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html-single/monitoring_and_logging/index[Monitoring and Logging]
-* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html-single/telemetry_data_collection/index[Telemetry data collection]
+* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/monitoring_and_logging/index[Monitoring and Logging]
+* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/telemetry_data_collection/index[Telemetry data collection]
+* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/adoption_insights_in_red_hat_developer_hub/index[Adoption Insights]
 
 [#metrics-solution]
 === 🧞👨‍🔬 Metrics Solution


### PR DESCRIPTION
This PR extends the Observability challenge by enabling the Adoption Insights plugin. This is a Dev preview plugin, but very usefull to visualize the usage of the platform.