### PR TITLE
📝 (docs): Link to Red Hat Developer Hub 1.5 docs

### DIFF
--- a/documentation/modules/ROOT/pages/challenge-01.adoc
+++ b/documentation/modules/ROOT/pages/challenge-01.adoc
@@ -34,8 +34,8 @@ while also ensuring consistency and reducing human errors.
 
 To resolve this challenge you can start checking the following references:
 
-* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/installing_red_hat_developer_hub_on_openshift_container_platform/assembly-install-rhdh-ocp-helm[Installing Red Hat Developer Hub on OpenShift with the Helm Chart]
-* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/upgrading_red_hat_developer_hub/proc-upgrade-rhdh-helm_title-upgrade-rhdh[Upgrading the Red Hat Developer Hub Helm Chart]
+* https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/installing_red_hat_developer_hub_on_openshift_container_platform/assembly-install-rhdh-ocp-helm[Installing Red Hat Developer Hub on OpenShift with the Helm Chart]
+* https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/upgrading_red_hat_developer_hub/proc-upgrade-rhdh-helm_title-upgrade-rhdh[Upgrading the Red Hat Developer Hub Helm Chart]
 * link:https://developers.redhat.com/learn/deploying-and-troubleshooting-red-hat-developer-hub-openshift-practical-guide[Deploying and Troubleshooting Red Hat Developer Hub on OpenShift: A Practical Guide]
 
 [#helm-solution]
@@ -59,8 +59,8 @@ This automation significantly reduces operational overhead while maintaining con
 
 To resolve this challenge you can start checking the following references:
 
-* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/installing_red_hat_developer_hub_on_openshift_container_platform/assembly-install-rhdh-ocp-operator[Installing Red Hat Developer Hub on OpenShift with the Operator]
-* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/upgrading_red_hat_developer_hub/proc-upgrade-rhdh-operator_title-upgrade-rhdh[Upgrading the Red Hat Developer Hub]
+* https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/installing_red_hat_developer_hub_on_openshift_container_platform/assembly-install-rhdh-ocp-operator[Installing Red Hat Developer Hub on OpenShift with the Operator]
+* https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/upgrading_red_hat_developer_hub/proc-upgrade-rhdh-operator_title-upgrade-rhdh[Upgrading the Red Hat Developer Hub]
 * link:https://developers.redhat.com/learn/deploying-and-troubleshooting-red-hat-developer-hub-openshift-practical-guide[Deploying and Troubleshooting Red Hat Developer Hub on OpenShift: A Practical Guide]
 
 [#operator-solution]

--- a/documentation/modules/ROOT/pages/challenge-02.adoc
+++ b/documentation/modules/ROOT/pages/challenge-02.adoc
@@ -36,9 +36,9 @@ modifying the application's deployment manifests directly, showcasing the flexib
 
 To resolve this challenge you can start checking the following references:
 
-* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/configuring/provisioning-and-using-your-custom-configuration[Provisioning and using your custom Red Hat Developer Hub configuration]
-* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html-single/customizing/index#customizing-your-product-se-url[Customizing your Red Hat Developer Hub base URL]
-* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/customizing/customizing-the-backend-secret[Customizing Red Hat Developer Hub backend secret]
+* https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/configuring_red_hat_developer_hub/provisioning-and-using-your-custom-configuration[Provisioning and using your custom Red Hat Developer Hub configuration]
+* https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/customizing_red_hat_developer_hub/customizing-your-product-se-url[Customizing your Red Hat Developer Hub base URL]
+* https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/customizing_red_hat_developer_hub/customizing-the-backend-secret[Customizing Red Hat Developer Hub backend secret]
 
 [#configuration-solution]
 === 🧞🛠️ External configuration Solution
@@ -54,7 +54,7 @@ custom settings into the application.
 
 To resolve this challenge you can start checking the following references:
 
-* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/customizing/customizing-your-product-title[Customizing your Red Hat Developer Hub title]
+* https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/customizing_red_hat_developer_hub/customizing-your-product-title[Customizing your Red Hat Developer Hub title]
 
 
 [#title-solution]
@@ -71,7 +71,7 @@ user experience while maintaining separation of concerns between deployment and 
 
 To resolve this challenge you can start checking the following references:
 
-* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/customizing/customizing-appearance[Customizing your Red Hat Developer Hub appearance]
+* https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/customizing_red_hat_developer_hub/customizing-appearance[Customizing your Red Hat Developer Hub appearance]
 
 [#colors-solution]
 === 🧞🌈 Looking better Solution

--- a/documentation/modules/ROOT/pages/challenge-03-solution.adoc
+++ b/documentation/modules/ROOT/pages/challenge-03-solution.adoc
@@ -14,7 +14,7 @@ in the future. Let' 's dive in together! 🧞🚀
 == 🧞🔑 Authentication with GitHub Solution
 
 Enabling GitHub authentication requires to create a GitHub application. This process  is described
-link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/authentication/authenticating-with-github#enabling-authentication-with-github[here]
+https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/authentication_in_red_hat_developer_hub/authenticating-with-github[here]
 
 To enable discovery, then you need to use a GitHub organization
 
@@ -293,7 +293,7 @@ The list of dynamic plugins to enable for this fully integration with GitHub is:
 * `backstage-plugin-catalog-backend-module-github-org-dynamic`
 * `backstage-plugin-scaffolder-backend-module-github-dynamic`
 
-More information about Dynamic Plugins link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html-single/introduction_to_plugins/index[here].
+More information about Dynamic Plugins https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html-single/introduction_to_plugins/index[here].
 
 The following steps will depend of the mechanism used to operate Red Hat Developer Hub:
 
@@ -637,7 +637,7 @@ Finally, we need to enable some extra dynamic plugins to setup finally the integ
 * backstage-plugin-catalog-backend-module-gitlab-org-dynamic
 * backstage-plugin-scaffolder-backend-module-gitlab-dynamic
 
-More information about Dynamic Plugins link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html-single/introduction_to_plugins/index[here].
+More information about Dynamic Plugins https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html-single/introduction_to_plugins/index[here].
 
 The following steps will depend of the mechanism used to operate Red Hat Developer Hub:
 

--- a/documentation/modules/ROOT/pages/challenge-03.adoc
+++ b/documentation/modules/ROOT/pages/challenge-03.adoc
@@ -40,7 +40,7 @@ Use a public organization or your own user in link:https://github.com[GitHub] as
 
 To resolve this challenge you can start checking the following references:
 
-* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/authentication/authenticating-with-github[Authenticating with GitHub]
+* https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/authentication_in_red_hat_developer_hub/authenticating-with-github[Authenticating with GitHub]
 * link:https://backstage.io/docs/auth/github/provider/[GitHub Authentication Provider]
 * link:https://developers.redhat.com/learn/streamline-development-github-integration-and-software-templates-red-hat-developer-hub[Streamline Development: GitHub Integration and Software Templates in Red Hat Developer Hub]
 
@@ -84,7 +84,7 @@ access to specific features or actions, ensuring users have the correct permissi
 
 To resolve this challenge you can start checking the following references:
 
-* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html-single/authorization/index#enabling-and-giving-access-to-rbac[Enabling and giving access to the RBAC feature]
+* https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html-single/authorization/index#enabling-and-giving-access-to-rbac[Enabling and giving access to the RBAC feature]
 
 [#rbac-solution]
 === 🧞🛂 You won't break it Solution

--- a/documentation/modules/ROOT/pages/challenge-06-solution.adoc
+++ b/documentation/modules/ROOT/pages/challenge-06-solution.adoc
@@ -34,7 +34,7 @@ or rebuilding container images.
 
 Red Hat Developer Hub is pre-loaded with a selection of dynamic plugins. Most of these dynamic plugins are disabled by default due
 to the need for mandatory configuration. For a complete list of dynamic plugins that are included, see the
-link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/dynamic_plugins_reference/con-preinstalled-dynamic-plugins#red-hat-supported-plugins[dynamic plugins matrix]
+https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/dynamic_plugins_reference/con-preinstalled-dynamic-plugins#red-hat-supported-plugins[dynamic plugins matrix]
 section of Red Hat Developer Hub.
 
 NOTE: Red Hat fully supports certain plugins (Topology, Tekton, Quay), while others are community-supported projects.
@@ -116,7 +116,7 @@ The following resources includes a full list of the current plugins in the Backs
 * link:https://github.com/backstage/community-plugins[Backstage Community Plugins]
 
 A detailed guide to install third-party plugins is available
-link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html-single/installing_and_viewing_plugins_in_red_hat_developer_hub/index#ref-example-third-party-plugin-installation_assembly-install-third-party-plugins-rhdh[here].
+https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html-single/installing_and_viewing_plugins_in_red_hat_developer_hub/index#ref-example-third-party-plugin-installation_assembly-install-third-party-plugins-rhdh[here].
 
 We will do the exercise to install some plugins using the dynamic plugin framework of Red Hat Developer Hub.
 

--- a/documentation/modules/ROOT/pages/challenge-06.adoc
+++ b/documentation/modules/ROOT/pages/challenge-06.adoc
@@ -39,10 +39,10 @@ It will be fun!!!
 
 To resolve this challenge you can start checking the following references:
 
-* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html-single/introduction_to_plugins/index[Introduction to plugins]
-* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/installing_and_viewing_plugins_in_red_hat_developer_hub/index[Installing and viewing plugins in Red Hat Developer Hub]
-* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/dynamic_plugins_reference/index[Dynamic plugins reference]
-* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/configuring_dynamic_plugins/index[Configuring dynamic plugins]
+* https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html-single/introduction_to_plugins/index[Introduction to plugins]
+* https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/installing_and_viewing_plugins_in_red_hat_developer_hub/index[Installing and viewing plugins in Red Hat Developer Hub]
+* https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/dynamic_plugins_reference/index[Dynamic plugins reference]
+* https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html/configuring_dynamic_plugins/index[Configuring dynamic plugins]
 * link:https://backstage.io/plugins/[Backstage Plugins]
 
 [#dynamicplugins-solution]


### PR DESCRIPTION
This PR completes the migration of links to RHDH 1.5 official site.