### PR TITLE
Fix release version

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -25,5 +25,7 @@ jobs:
         with:
           publish: true
           prerelease: false
+          name: ${{ github.ref_name }}
+          tag: ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -22,7 +22,7 @@ jobs:
         name: Checkout code
         uses: actions/checkout@v4.1.1
         with:
-          ref: main
+          ref: master
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - id: update-contributors


### PR DESCRIPTION
This PR fixes the usage of the pushed tag to release a new version, instead of generating a new one.