### PR TITLE
Upgrade operator to RHDH 1.6

### DIFF
--- a/documentation/modules/ROOT/examples/challenge-07/rhdh-dynamic-plugins-cm-github-01.yaml
+++ b/documentation/modules/ROOT/examples/challenge-07/rhdh-dynamic-plugins-cm-github-01.yaml
@@ -64,9 +64,9 @@ data:
       - package: ./dynamic-plugins/dist/roadiehq-backstage-plugin-github-insights
         disabled: false
       # Adoption Analytics
-      - package: './dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment'
+      - package: ./dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment
         disabled: true
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-adoption-insights:bs_1.35.1__0.0.2!red-hat-developer-hub-backstage-plugin-adoption-insights
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-adoption-insights:bs_1.35.1__0.0.3!red-hat-developer-hub-backstage-plugin-adoption-insights
         disabled: false
         pluginConfig:
           dynamicPlugins:
@@ -85,7 +85,7 @@ data:
                   adoption-insights:
                     parent: admin
                     icon: adoptionInsightsIcon
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-adoption-insights-backend:bs_1.35.1__0.0.2!red-hat-developer-hub-backstage-plugin-adoption-insights-backend-dynamic
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-adoption-insights-backend:bs_1.35.1__0.0.4!red-hat-developer-hub-backstage-plugin-adoption-insights-backend
         disabled: false
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights:bs_1.35.1__0.0.2!red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights
         disabled: false

--- a/documentation/modules/ROOT/examples/challenge-07/rhdh-dynamic-plugins-cm-gitlab-01.yaml
+++ b/documentation/modules/ROOT/examples/challenge-07/rhdh-dynamic-plugins-cm-gitlab-01.yaml
@@ -59,9 +59,9 @@ data:
       - package: oci://quay.io/rhdh-adventure-organization/backstage-community-plugin-todo:v0.1.2!backstage-community-plugin-todo-backend-dynamic
         disabled: false
       # Adoption Analytics
-      - package: './dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment'
+      - package: ./dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment
         disabled: true
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-adoption-insights:bs_1.35.1__0.0.2!red-hat-developer-hub-backstage-plugin-adoption-insights
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-adoption-insights:bs_1.35.1__0.0.3!red-hat-developer-hub-backstage-plugin-adoption-insights
         disabled: false
         pluginConfig:
           dynamicPlugins:
@@ -80,7 +80,7 @@ data:
                   adoption-insights:
                     parent: admin
                     icon: adoptionInsightsIcon
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-adoption-insights-backend:bs_1.35.1__0.0.2!red-hat-developer-hub-backstage-plugin-adoption-insights-backend-dynamic
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-adoption-insights-backend:bs_1.35.1__0.0.4!red-hat-developer-hub-backstage-plugin-adoption-insights-backend
         disabled: false
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights:bs_1.35.1__0.0.2!red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights
         disabled: false

--- a/documentation/modules/ROOT/examples/setup/gitlab-operator.yaml
+++ b/documentation/modules/ROOT/examples/setup/gitlab-operator.yaml
@@ -24,5 +24,5 @@ spec:
   source: certified-operators
   sourceNamespace: openshift-marketplace
   channel: stable
-  startingCSV: gitlab-operator-kubernetes.v1.10.0
+  startingCSV: gitlab-operator-kubernetes.v2.0.1
   installPlanApproval: Automatic

--- a/documentation/modules/ROOT/examples/setup/gitlab.yaml
+++ b/documentation/modules/ROOT/examples/setup/gitlab.yaml
@@ -22,4 +22,4 @@ spec:
             enabled: false
       nginx-ingress:
         enabled: false
-    version: 8.9.2
+    version: 9.0.1

--- a/documentation/modules/ROOT/examples/setup/rhdh-operator.yaml
+++ b/documentation/modules/ROOT/examples/setup/rhdh-operator.yaml
@@ -26,5 +26,5 @@ spec:
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   channel: fast
-  startingCSV: rhdh-operator.v1.4.2
+  startingCSV: rhdh-operator.v1.6.0
   installPlanApproval: Automatic

--- a/documentation/modules/ROOT/pages/01-setup.adoc
+++ b/documentation/modules/ROOT/pages/01-setup.adoc
@@ -57,7 +57,7 @@ It the output is similar to, then it is not needed to install it.
 [source, bash, subs="+macros,+attributes"]
 ----
 NAME                            DISPLAY                                       VERSION   REPLACES                        PHASE
-cert-manager-operator.v1.15.1   cert-manager Operator for Red Hat OpenShift   1.15.1    cert-manager-operator.v1.14.2   Succeeded
+cert-manager-operator.v1.16.0   cert-manager Operator for Red Hat OpenShift   1.16.0    cert-manager-operator.v1.15.1   Succeeded
 ----
 
 To install it:
@@ -102,7 +102,7 @@ The output is similar to:
 [source, bash, subs="+macros,+attributes"]
 ----
 NAME                   DISPLAY                          VERSION   REPLACES               PHASE
-rhdh-operator.v1.5.1   Red Hat Developer Hub Operator   1.5.1     rhdh-operator.v1.4.2   Succeeded
+rhdh-operator.v1.6.1   Red Hat Developer Hub Operator   1.6.1     rhdh-operator.v1.6.0   Succeeded
 ----
 
 [#ocpsetup-gitlab]
@@ -136,7 +136,7 @@ The output is similar to:
 [source, bash, subs="+macros,+attributes"]
 ----
 NAME                                DISPLAY    VERSION   REPLACES                            PHASE
-gitlab-operator-kubernetes.v1.11.0  GitLab     1.11.0    gitlab-operator-kubernetes.v1.10.2  Succeeded
+gitlab-operator-kubernetes.v2.0.1   GitLab     2.0.1     gitlab-operator-kubernetes.v2.0.0   Succeeded
 ----
 
 To install a local instance of GitLab this command will create one. It will the base domain of the

--- a/documentation/modules/ROOT/pages/challenge-06-solution.adoc
+++ b/documentation/modules/ROOT/pages/challenge-06-solution.adoc
@@ -414,7 +414,7 @@ For GitHub:
 [.console-input]
 [source, bash, subs="+macros,+attributes"]
 ----
-oc apply -f ./documentation/modules/ROOT/examples/challenge-06/rhdh-dynamic-plugins-cm-github.yaml
+oc apply -f ./documentation/modules/ROOT/examples/challenge-06/rhdh-dynamic-plugins-cm-github-02.yaml
 ----
 
 For GitLab:
@@ -422,7 +422,7 @@ For GitLab:
 [.console-input]
 [source, bash, subs="+macros,+attributes"]
 ----
-oc apply -f ./documentation/modules/ROOT/examples/challenge-06/rhdh-dynamic-plugins-cm-gitlab.yaml
+oc apply -f ./documentation/modules/ROOT/examples/challenge-06/rhdh-dynamic-plugins-cm-gitlab-02.yaml
 ----
 --
 ====


### PR DESCRIPTION
This PR includes an upgrade of the content aligned with the Red Hat Developer Hub 1.6 version.
